### PR TITLE
ROCKS7: Create rocksdb group and user at next available service account ID

### DIFF
--- a/nodes/database.xml
+++ b/nodes/database.xml
@@ -338,6 +338,8 @@
 	line find the host 'localhost' correctly
 -->
 /bin/hostname &hostname;
+</post>
+
 
 <!--
 	Add the rocksdb user and group to the system.
@@ -345,9 +347,18 @@
 	Also setup the correct directories and their
 	permissions for running the database
 -->
+
+<post cond="rocks_version_major == 7">
+getent group rocksdb &gt;/dev/null || groupadd -r rocksdb
+getent passwd rocksdb &gt;/dev/null || useradd -r -g rocksdb -d /var/opt/rocks/mysql -m -s /bin/false rocksdb
+</post>
+
+<post cond="rocks_version_major == 6">
 groupadd -g 403 rocksdb
 useradd -u 403 -g rocksdb -d /var/opt/rocks/mysql -m -s /bin/false rocksdb
+</post>
 
+<post>
 /opt/rocks/mysql/sbin/mysql-install-db
 
 chgrp -R rocksdb /var/opt/rocks/mysql


### PR DESCRIPTION
RHEL and CentOS 7 increase the UID_MIN value from 500 to 1000. When creating service accounts the UID is selected as the 'next highest' UID available in the range. Creating rocksdb service account with fix UID/GID of 403 effectively restricts all service accounts/groups created after rocksdb is created to values below 403 reversing the change the OS has implemented. Add rocksdb account in <post> in manner similar to that used in RPM postinstall scriptlets.