### PR TITLE
Include contents of /etc/ssh/shosts.equiv.local in output of 'rocks report shosts'

### DIFF
--- a/src/rocks-pylib/rocks/commands/add/appliance/route/__init__.py
+++ b/src/rocks-pylib/rocks/commands/add/appliance/route/__init__.py
@@ -141,7 +141,7 @@ class Command(rocks.commands.add.appliance.command):
 			gateway = "''"
 		else:
 			subnet = None
-			gateway = "'%s'" % gateway
+			gateway = "%s" % gateway
 
 		# Now that we know things will work insert the route for
 		# all the appliances

--- a/src/rocks-pylib/rocks/commands/report/shosts/__init__.py
+++ b/src/rocks-pylib/rocks/commands/report/shosts/__init__.py
@@ -93,7 +93,18 @@ class Command(command):
 				# Construct the shosts entry we only use the ip
 				h = '%s' % (ip)
 				self.addOutput('localhost', h)
-		
+
+		# Finally, add the ssh_known_hosts.local file to the list
+		shostlocal = '/etc/ssh/shosts.equiv.local'
+		try:
+			f = open(shostlocal,'r')
+			self.addOutput('localhost','#\n# Imported from %s\n#' % shostlocal)
+			h = f.read()
+			self.addOutput('localhost',h)
+			f.close()
+		except :
+			pass
+               
 		self.addOutput('localhost', '</file>')
 		self.endOutput(padChar='')
 

--- a/src/rocks-pylib/rocks/commands/report/shosts/__init__.py
+++ b/src/rocks-pylib/rocks/commands/report/shosts/__init__.py
@@ -94,7 +94,7 @@ class Command(command):
 				h = '%s' % (ip)
 				self.addOutput('localhost', h)
 
-		# Finally, add the ssh_known_hosts.local file to the list
+		# Finally, add the shosts.equiv.local file to the list
 		shostlocal = '/etc/ssh/shosts.equiv.local'
 		try:
 			f = open(shostlocal,'r')


### PR DESCRIPTION
Allows trusting hosts outside of the cluster for hostbased authentication. (Hostbased auth with external hosts is partially implemented with knownhosts, however this component is missing.)