### PR TITLE
Modify build.py resolveVersions(self, files):

### DIFF
--- a/src/rocks-pylib/rocks/build.py
+++ b/src/rocks-pylib/rocks/build.py
@@ -1551,7 +1551,7 @@ class DistributionBuilder(Builder):
         dict = {}
         for e in files:
             name = e.getUniqueName() # name w/ arch string appended
-            if not dict.has_key(name) or e >= dict[name]:
+            if not dict.has_key(name) or e.getName() >= dict[name].getName():
                 dict[name] = e
 
         # Extract the File objects from the dictionary and return


### PR DESCRIPTION
Found that "rocks create distro" did not use the latest rpm release following
rebuild of an unrelated Roll.
The resolveVersions was using the comparision operation from the File class
which uses getUniqueName() which has the package name and arch but not the release.

from if not dict.has_key(name) or e >= dict[name]:
to     if not dict.has_key(name) or e.getName() >= dict[name].getName():
so that rpm release is include in comparision.

Fo