### PR TITLE
Rocks 7 bootaction "install" and "install headless"

### DIFF
--- a/nodes/core-pxe.xml
+++ b/nodes/core-pxe.xml
@@ -47,7 +47,7 @@ chmod 775 /tftpboot/pxelinux/pxelinux.cfg
 /opt/rocks/bin/rocks add bootaction action="install" \
 	kernel="vmlinuz-&version;-&arch;" \
 	ramdisk="initrd.img-&version;-&arch;" \
-	args="inst.ks.sendmac inst.sshd lang= devfs=nomount selinux=0 ipv6.disable=1 rocks=client ksdevice=bootif inst.repo=http://127.0.0.1/&Kickstart_PrivateKickstartBasedir;/rocks-dist/&arch; inst.ks=http://localhost/fetchRocksKS.py inst.updates=http://127.0.0.1/&Kickstart_PrivateKickstartBasedir;/rocks-dist/&arch;/images/updates.img rocks.ks=https://&Kickstart_PrivateKickstartHost;/&Kickstart_PrivateKickstartBasedir;/&Kickstart_PrivateKickstartCGI; tracker.trackers=&Kickstart_PrivateKickstartHost;"
+	args="inst.ks.sendmac inst.sshd lang= devfs=nomount selinux=0 ipv6.disable=1 rocks=client ksdevice=bootif inst.repo=http://&Kickstart_PrivateKickstartHost;/&Kickstart_PrivateKickstartBasedir;/rocks-dist/&arch; inst.ks=http://localhost/fetchRocksKS.py inst.updates=http://&Kickstart_PrivateKickstartHost;/&Kickstart_PrivateKickstartBasedir;/rocks-dist/&arch;/images/updates.img rocks.ks=https://&Kickstart_PrivateKickstartHost;/&Kickstart_PrivateKickstartBasedir;/&Kickstart_PrivateKickstartCGI; tracker.trackers=&Kickstart_PrivateKickstartHost;"
 
 /opt/rocks/bin/rocks add bootaction action="install notracker" \
 	kernel="vmlinuz-&version;-&arch;" \
@@ -60,7 +60,7 @@ chmod 775 /tftpboot/pxelinux/pxelinux.cfg
 /opt/rocks/bin/rocks add bootaction action="install headless" \
 	kernel="vmlinuz-&version;-&arch;" \
 	ramdisk="initrd.img-&version;-&arch;" \
-	args="inst.vnc inst.ks.sendmac inst.sshd lang= devfs=nomount selinux=0 ipv6.disable=1 rocks=client ksdevice=bootif inst.repo=http://127.0.0.1/&Kickstart_PrivateKickstartBasedir;/rocks-dist/&arch; inst.ks=http://localhost/fetchRocksKS.py inst.updates=http://127.0.0.1/&Kickstart_PrivateKickstartBasedir;/rocks-dist/&arch;/images/updates.img rocks.ks=https://&Kickstart_PrivateKickstartHost;/&Kickstart_PrivateKickstartBasedir;/&Kickstart_PrivateKickstartCGI; tracker.trackers=&Kickstart_PrivateKickstartHost;"
+	args="inst.vnc inst.ks.sendmac inst.sshd lang= devfs=nomount selinux=0 ipv6.disable=1 rocks=client ksdevice=bootif inst.repo=http://&Kickstart_PrivateKickstartHost;/&Kickstart_PrivateKickstartBasedir;/rocks-dist/&arch; inst.ks=http://localhost/fetchRocksKS.py inst.updates=http://&Kickstart_PrivateKickstartHost;/&Kickstart_PrivateKickstartBasedir;/rocks-dist/&arch;/images/updates.img rocks.ks=https://&Kickstart_PrivateKickstartHost;/&Kickstart_PrivateKickstartBasedir;/&Kickstart_PrivateKickstartCGI; tracker.trackers=&Kickstart_PrivateKickstartHost;"
 
 /opt/rocks/bin/rocks add bootaction action="install headless notracker" \
 	kernel="vmlinuz-&version;-&arch;" \

--- a/src/rocks-pylib/rocks/build.py
+++ b/src/rocks-pylib/rocks/build.py
@@ -1551,7 +1551,7 @@ class DistributionBuilder(Builder):
         dict = {}
         for e in files:
             name = e.getUniqueName() # name w/ arch string appended
-            if not dict.has_key(name) or e >= dict[name]:
+            if not dict.has_key(name) or e.getName() >= dict[name].getName():
                 dict[name] = e
 
         # Extract the File objects from the dictionary and return


### PR DESCRIPTION
Following Rocks 7 server installation the bootaction "install" and "install headless"
appear to be incorrect. A subsequent compute node installation fails.
The bootaction have URLs with hostaddresses 127.0.0.1 which should be
the value of attribute Kickstart_PrivateKickstartHost
