### PR TITLE
Correction to avoid 'Argument list too long' error when creating packages with many files

### DIFF
--- a/src/devel/devel/etc/Rules-linux-centos.mk
+++ b/src/devel/devel/etc/Rules-linux-centos.mk
@@ -458,7 +458,7 @@ ifeq ($(RPM.PREFIX),)
 ifeq ($(RPM.FILES),)
 	@$(PF) "/\n" >> $@
 else
-	@$(PF) "$(RPM.FILES)\n" >> $@
+	tail -n 1 version.mk | sed -e 's/\\n/\n/g' | sed -e 's/RPM.FILES=//g'| sed -e 's/^/"/g' | sed -e 's/$$/"/g' >> $@
 endif
 else
 	@$(PF) "$(RPM.PREFIX)\n" >> $@


### PR DESCRIPTION
Me and @felipedreis found out that on packages that have many files an error is thrown when trying to write the list of files on the $(NAME).spec file.

The error was found when running `rocks  create package` on a software installation that had a lot of files.

This happens because the rule $(NAME).spec on 'Rules-linux-centos.mk' tries to write the entire list of RPM.FILES at once using the printf command,
and on big packages the argument list passed to printf overflow the shell constant ARG_MAX.

This could be solved relying on the fact that the RPM.FILES list was already written on the 'version.mk' file. Using the tail command made possible to
directly transfer the filelist from one file to another.

Also, the tail command was piped through sequences of 'sed' commands that replaced the '\\n' character to the actually newline, and escaped each path with "". This was done to prevent another error that rose when the paths had spaces on them which were interpreted as separators.

Those changes were tested on a virtual machine installation of Rocks 7.0 and worked fine producing an installable and fully functional package. We tested with 12 different softwares.